### PR TITLE
Include graphviz in dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -26,6 +26,7 @@ requirements:
     - numpydoc
     - sphinx-automodapi
     - sphinx-gallery
+    - graphviz
   run:
     - python
     - sphinx >=1.4
@@ -33,6 +34,7 @@ requirements:
     - numpydoc
     - sphinx-automodapi
     - sphinx-gallery
+    - graphviz
 
 test:
   imports:


### PR DESCRIPTION
We can't add graphviz as a sphinx-astropy dependency in the Python package, but since graphviz is in conda, we can include it as a dependency here.